### PR TITLE
Fix no username key local storage bug

### DIFF
--- a/src/Components/LoginPage/LoginView.tsx
+++ b/src/Components/LoginPage/LoginView.tsx
@@ -64,7 +64,8 @@ export default function LoginPage({ setUserData }: LoginViewProps) {
   }, []);
 
   useEffect(() => {
-    if (localStorage.getItem("username") !== "") {
+    const storedUser = localStorage.getItem("username");
+    if (storedUser !== null && storedUser !== "") {
       navigate("/UserProfile");
     }
   }, []);

--- a/src/Components/SharedComponents/AutocompleteFormField.tsx
+++ b/src/Components/SharedComponents/AutocompleteFormField.tsx
@@ -5,7 +5,7 @@ import Autocomplete, { createFilterOptions } from "@mui/material/Autocomplete";
 const filter = createFilterOptions<string>();
 
 interface Props {
-  defaultValue?: string;
+  defaultValue: string;
   options: string[];
   fieldLabel: string;
   setChoreRequestData: Dispatch<SetStateAction<ChoreRequest>>;
@@ -17,8 +17,8 @@ export default function AutocompleteFormField({
   setChoreRequestData,
   defaultValue,
 }: Props) {
-  const [value, setValue] = useState<string | null>(null);
-  const [inputValue, setInputValue] = useState<string | undefined>(undefined);
+  const [value, setValue] = useState<string | null>(defaultValue);
+  const [inputValue, setInputValue] = useState<string>(defaultValue);
 
   const handleInputChange = (fieldName: string, fieldValue: string | null) => {
     setChoreRequestData((prevState: ChoreRequest) => ({


### PR DESCRIPTION
When a user has never used our app before, they have no key called "username" in their localStorage. This caused a bug with the old code, because they would still be sent to the User profile page and  not be able to view the Login page.

Now the code for the useEffect on the login page checks if there is a key called username and if it is not an empty string before navigating to the User profile.